### PR TITLE
FG openning of

### DIFF
--- a/src/zcl_adtco_uri_mapper.clas.abap
+++ b/src/zcl_adtco_uri_mapper.clas.abap
@@ -328,7 +328,11 @@ CLASS zcl_adtco_uri_mapper IMPLEMENTATION.
 
 
     IF uri IS NOT INITIAL.
-      uri = |/sap/bc/adt/programs/{ uri }|.
+      IF original_object_type  CP prefix-fugr_pattern.
+       uri = |/sap/bc/adt/functions/groups/{ original_object_name }/{ uri }|.
+      ELSE.
+        uri = |/sap/bc/adt/programs/{ uri }|.
+      ENDIF.
     ENDIF.
   ENDMETHOD.
 


### PR DESCRIPTION
When you used double click on element of FG that was stored in an include (like method implementation) then the URI was build as for program include, not FG include. This made that the object was not correctly opened and the FG tree was not kept