### PR TITLE
short dump if class does not exists yet

### DIFF
--- a/src/package.devc.xml
+++ b/src/package.devc.xml
@@ -3,7 +3,7 @@
  <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
   <asx:values>
    <DEVC>
-    <CTEXT>Classic Outline</CTEXT>
+    <CTEXT>ADT Classic outline backend</CTEXT>
    </DEVC>
   </asx:values>
  </asx:abap>

--- a/src/zcl_adtco_tree_creator.clas.abap
+++ b/src/zcl_adtco_tree_creator.clas.abap
@@ -44,7 +44,26 @@ ENDCLASS.
 
 
 
-CLASS zcl_adtco_tree_creator IMPLEMENTATION.
+CLASS ZCL_ADTCO_TREE_CREATOR IMPLEMENTATION.
+
+
+  METHOD add_sublcasses.
+    CHECK original_object_type EQ 'CLAS/OC'.
+
+    ASSIGN tree[ type = 'COU' ] TO FIELD-SYMBOL(<parent>).
+    IF sy-subrc EQ 0.
+      DATA(counter) = get_counter( tree ).
+      DATA(subclasses) = get_subclasses( CONV #( original_object_name ) ).
+      LOOP AT subclasses ASSIGNING FIELD-SYMBOL(<subclass>).
+        IF <parent>-child IS INITIAL.
+          <parent>-child = counter.
+        ENDIF.
+        APPEND VALUE #( text1 = <subclass>-clsname parent = <parent>-id id = counter type = 'OOC' text2 = get_class_description( <subclass>-clsname )  ) TO tree.
+        ADD 1 TO counter.
+      ENDLOOP.
+    ENDIF.
+  ENDMETHOD.
+
 
   METHOD create_tree.
     CALL FUNCTION 'WB_ANYTYPE_RETURN_OBJECT_LIST'
@@ -78,8 +97,18 @@ CLASS zcl_adtco_tree_creator IMPLEMENTATION.
                     CHANGING  tree                 = tree ).
   ENDMETHOD.
 
-  METHOD get_object_type.
-    object_type = original_object_type(4).
+
+  METHOD get_class_description.
+    TRY.
+        DATA(class) = CAST cl_oo_class( cl_oo_class=>get_instance( class_name ) ).
+        description = class->class-descript.
+      CATCH cx_class_not_existent ##no_handler.
+    ENDTRY.
+  ENDMETHOD.
+
+
+  METHOD get_counter.
+    counter = tree[ lines( tree ) ]-id + 1.
   ENDMETHOD.
 
 
@@ -101,31 +130,8 @@ CLASS zcl_adtco_tree_creator IMPLEMENTATION.
   ENDMETHOD.
 
 
-  METHOD add_sublcasses.
-    CHECK original_object_type EQ 'CLAS/OC'.
-
-    ASSIGN tree[ type = 'COU' ] TO FIELD-SYMBOL(<parent>).
-    IF sy-subrc EQ 0.
-      DATA(counter) = get_counter( tree ).
-      DATA(subclasses) = get_subclasses( CONV #( original_object_name ) ).
-      LOOP AT subclasses ASSIGNING FIELD-SYMBOL(<subclass>).
-        IF <parent>-child IS INITIAL.
-          <parent>-child = counter.
-        ENDIF.
-        APPEND VALUE #( text1 = <subclass>-clsname parent = <parent>-id id = counter type = 'OOC' text2 = get_class_description( <subclass>-clsname )  ) TO tree.
-        ADD 1 TO counter.
-      ENDLOOP.
-    ENDIF.
-  ENDMETHOD.
-
-  METHOD get_counter.
-    counter = tree[ lines( tree ) ]-id + 1.
-  ENDMETHOD.
-
-
-  METHOD get_class_description.
-    DATA(class) = CAST cl_oo_class( cl_oo_class=>get_instance( class_name ) ).
-    description = class->class-descript.
+  METHOD get_object_type.
+    object_type = original_object_type(4).
   ENDMETHOD.
 
 
@@ -133,5 +139,4 @@ CLASS zcl_adtco_tree_creator IMPLEMENTATION.
     subclasses =  CAST cl_oo_class( cl_oo_class=>get_instance( CONV #( class_name ) ) )->get_subclasses( ).
     SORT subclasses BY clsname.
   ENDMETHOD.
-
 ENDCLASS.


### PR DESCRIPTION
when creating a new class and the class does not exists, the plugin tries to read the class data. if class does not exist, exception CX_CLASS_NOT_EXISTENT will be raised. as this excpetion is not handled there will be a short dump.